### PR TITLE
fix(README): update GitHub Action repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,6 @@ jobs:
           aws-region: ${{ env.aws_region }}
 
     - name: AWS CLI Command
-      uses: nicholasarvelo/aws-cli-action@v1
+      uses: nicholasarvelo/aws-cli-commands@v1
       with:
         args: s3 cp ${{ env.cp_source }} ${{ env.cp_destination }} 


### PR DESCRIPTION
Corrected the GitHub Action repository name in the README.md usage example. Changed from 'nicholasarvelo/aws-cli-action@v1' to 'nicholasarvelo/aws-cli-commands@v1', ensuring accurate guidance for users on how to implement the action in their workflows.